### PR TITLE
Clean up post categories: fix spelling and consolidate terms

### DIFF
--- a/posts/grace-ac-WSN/index.qmd
+++ b/posts/grace-ac-WSN/index.qmd
@@ -8,7 +8,7 @@ author:
     affiliation: UW - School of Aquatic and Fishery Sciences
     affiliation-url: https://faculty.washington.edu/sr320/
 date: 11-15-2023
-categories: [wsn, meeting, seastar] # self-defined categories
+categories: [wsn, meeting, sea star] # self-defined categories
 image: https://github.com/grace-ac/grace-ac.github.io/raw/master/notebook-images/2023-11-15-wsn-recap/IMG_1750.jpg # finding a good image
 draft: false # setting this to `true` will prevent your post from appearing on your listing page until you're ready!
 

--- a/posts/grace_L_WSN/index.qmd
+++ b/posts/grace_L_WSN/index.qmd
@@ -8,7 +8,7 @@ author:
     affiliation: UW - Department of Biology
     affiliation-url: https://faculty.washington.edu/sr320/
 date: 11-22-2023
-categories: [wsn, meeting, seastar] # self-defined categories
+categories: [wsn, meeting, sea star] # self-defined categories
 image: http://gannet.fish.washington.edu/seashell/snaps/Monosnap_graceleuchtenberger.github.iopost_images20231122WSN.jpeg_at_master__graceleuchtenbergergraceleuchtenberger.github.io_2023-12-11_14-07-16.png # finding a good image
 draft: false # setting this to `true` will prevent your post from appearing on your listing page until you're ready!
 

--- a/posts/megan-rna/index.qmd
+++ b/posts/megan-rna/index.qmd
@@ -6,7 +6,7 @@ author:
     affiliation: UW - School of Aquatic and Fishery Sciences
  #   affiliation-url: https://robertslab.info
 date: 01-04-2024
-categories: [rnaseq, aquaculture, clam, stress] # self-defined categories
+categories: [rna-seq, aquaculture, clam, stress] # self-defined categories
 image: http://gannet.fish.washington.edu/seashell/snaps/Monosnap_mewing-notebook_-_Clam_Gonad_RNAseq_Analysis_2024-01-06_07-25-10.png # finding a good image
 draft: false # setting this to `true` will prevent your post from appearing on your listing page until you're ready!
 

--- a/posts/mytilus-genome/index.qmd
+++ b/posts/mytilus-genome/index.qmd
@@ -6,7 +6,7 @@ description: "The Genome of Mytilus chilensis"
 #    affiliation: Professor, UW - School of Aquatic and Fishery Sciences
  #   affiliation-url: https://robertslab.info
 date: 10-04-2023
-categories: [mussel, genome, Chile] # self-defined categories
+categories: [mussel, genomics, Chile] # self-defined categories
 image: http://gannet.fish.washington.edu/seashell/snaps/Monosnap_ChatGPT_2023-11-04_15-08-02.png # finding a good image
 draft: false # setting this to `true` will prevent your post from appearing on your listing page until you're ready!
 

--- a/posts/sr320-WSG/index.qmd
+++ b/posts/sr320-WSG/index.qmd
@@ -8,7 +8,7 @@ author:
     affiliation: Professor, UW - School of Aquatic and Fishery Sciences
     affiliation-url: https://robertslab.info
 date: 02-10-2025
-categories: [wsg, talk] # self-defined categories
+categories: [wsg, presentation] # self-defined categories
 image: http://gannet.fish.washington.edu/seashell/snaps/Monosnap_2025-WSG-Roberts_2025-02-10_07-20-44.png # finding a good image
 draft: false # setting this to `true` will prevent your post from appearing on your listing page until you're ready!
 

--- a/posts/sr320-epiaqua/index.qmd
+++ b/posts/sr320-epiaqua/index.qmd
@@ -8,7 +8,7 @@ author:
     affiliation: Professor, UW - School of Aquatic and Fishery Sciences
     affiliation-url: https://robertslab.info
 date: 01-30-2026
-categories: [teaching, aquaculture] # self-defined categories
+categories: [education, aquaculture] # self-defined categories
 image: http://gannet.fish.washington.edu/seashell/snaps/Monosnap_Image_2026-01-30_11-26-05.png # finding a good image
 draft: false # setting this to `true` will prevent your post from appearing on your listing page until you're ready!
 

--- a/posts/sr320-spencer-paper/index.qmd
+++ b/posts/sr320-spencer-paper/index.qmd
@@ -8,7 +8,7 @@ author:
     affiliation: Professor, UW - School of Aquatic and Fishery Sciences
     affiliation-url: https://robertslab.info
 date: 09-15-2023
-categories: [paper, acidication, oyster, ostrea, tag-seq] # self-defined categories
+categories: [paper, acidification, oyster, ostrea, tag-seq] # self-defined categories
 image: https://gannet.fish.washington.edu/seashell/snaps/httpswww.biorxiv.orgcontent10.11012023.09.08.556443v1.full.pdf_2023-09-14_12-56-48.png # finding a good image
 draft: false # setting this to `true` will prevent your post from appearing on your listing page until you're ready!
 


### PR DESCRIPTION
Correct misspelled tag and standardize variant/synonymous category terms across posts so listing filters group consistently:

- acidication -> acidification (spelling)
- rnaseq -> rna-seq
- seastar -> sea star
- genome -> genomics
- teaching -> education
- talk -> presentation