### PR TITLE
Redesign homepage for engagement (Phase 5)

### DIFF
--- a/docs/posts.html
+++ b/docs/posts.html
@@ -512,7 +512,7 @@ Feb 25, 2026
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="4" data-categories="dGVhY2hpbmclMkNhcXVhY3VsdHVyZQ==" data-listing-date-sort="1769760000000" data-listing-file-modified-sort="1781957779341" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="407">
+<div class="g-col-1" data-index="4" data-categories="dGVhY2hpbmclMkNhcXVhY3VsdHVyZQ==" data-listing-date-sort="1769760000000" data-listing-file-modified-sort="1781959433508" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="407">
 <a href="./posts/sr320-epiaqua/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">
@@ -1085,7 +1085,7 @@ Feb 20, 2025
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="21" data-categories="d3NnJTJDdGFsaw==" data-listing-date-sort="1739174400000" data-listing-file-modified-sort="1781957779340" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="377">
+<div class="g-col-1" data-index="21" data-categories="d3NnJTJDdGFsaw==" data-listing-date-sort="1739174400000" data-listing-file-modified-sort="1781959433507" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="377">
 <a href="./posts/sr320-WSG/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">
@@ -1412,7 +1412,7 @@ Jul 1, 2024
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="31" data-categories="bWV0aG9kcyUyQ3Rvb2xz" data-listing-date-sort="1716620400000" data-listing-file-modified-sort="1781958455138" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="551">
+<div class="g-col-1" data-index="31" data-categories="bWV0aG9kcyUyQ3Rvb2xz" data-listing-date-sort="1716620400000" data-listing-file-modified-sort="1781959333336" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="551">
 <a href="./posts/sr320-altsplice/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">
@@ -1445,7 +1445,7 @@ May 25, 2024
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="32" data-categories="bWV0aG9kcyUyQ3Rvb2xz" data-listing-date-sort="1715238000000" data-listing-file-modified-sort="1781958455140" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="291">
+<div class="g-col-1" data-index="32" data-categories="bWV0aG9kcyUyQ3Rvb2xz" data-listing-date-sort="1715238000000" data-listing-file-modified-sort="1781959333338" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="291">
 <a href="./posts/sr320-enrich/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">
@@ -1478,7 +1478,7 @@ May 9, 2024
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="33" data-categories="bWV0aG9kcyUyQ3Rvb2xz" data-listing-date-sort="1714978800000" data-listing-file-modified-sort="1781958455145" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="400">
+<div class="g-col-1" data-index="33" data-categories="bWV0aG9kcyUyQ3Rvb2xz" data-listing-date-sort="1714978800000" data-listing-file-modified-sort="1781959333336" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="400">
 <a href="./posts/ariana-hatchery/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">
@@ -1511,7 +1511,7 @@ May 6, 2024
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="34" data-categories="b3lzdGVyJTJDYXF1YWN1bHR1cmU=" data-listing-date-sort="1709884800000" data-listing-file-modified-sort="1781958455142" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="391">
+<div class="g-col-1" data-index="34" data-categories="b3lzdGVyJTJDYXF1YWN1bHR1cmU=" data-listing-date-sort="1709884800000" data-listing-file-modified-sort="1781959333338" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="391">
 <a href="./posts/sr320-oyster_stage/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">
@@ -1613,7 +1613,7 @@ Feb 2, 2024
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="37" data-categories="Y291cnNlJTJDZ2Vub21pY3MlMkNtZXRob2RzJTJDd2Vic2l0ZQ==" data-listing-date-sort="1705651200000" data-listing-file-modified-sort="1781958455135" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="493">
+<div class="g-col-1" data-index="37" data-categories="Y291cnNlJTJDZ2Vub21pY3MlMkNtZXRob2RzJTJDd2Vic2l0ZQ==" data-listing-date-sort="1705651200000" data-listing-file-modified-sort="1781959333337" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="493">
 <a href="./posts/sr320-asi/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">
@@ -1652,7 +1652,7 @@ Jan 19, 2024
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="38" data-categories="Y29kJTJDZ2Vub21pY3MlMkNlcGlnZW5ldGljcyUyQ3JuYS1zZXE=" data-listing-date-sort="1705478400000" data-listing-file-modified-sort="1781958340549" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="386">
+<div class="g-col-1" data-index="38" data-categories="Y29kJTJDZ2Vub21pY3MlMkNlcGlnZW5ldGljcyUyQ3JuYS1zZXE=" data-listing-date-sort="1705478400000" data-listing-file-modified-sort="1781959333337" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="386">
 <a href="./posts/sr320-cod/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">
@@ -1691,7 +1691,7 @@ Jan 17, 2024
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="39" data-categories="cm5hc2VxJTJDYXF1YWN1bHR1cmUlMkNjbGFtJTJDc3RyZXNz" data-listing-date-sort="1704355200000" data-listing-file-modified-sort="1781957779338" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="672">
+<div class="g-col-1" data-index="39" data-categories="cm5hc2VxJTJDYXF1YWN1bHR1cmUlMkNjbGFtJTJDc3RyZXNz" data-listing-date-sort="1704355200000" data-listing-file-modified-sort="1781959433505" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="672">
 <a href="./posts/megan-rna/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">
@@ -1730,7 +1730,7 @@ Jan 4, 2024
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="40" data-categories="d3NuJTJDbWVldGluZyUyQ3NlYXN0YXI=" data-listing-date-sort="1700640000000" data-listing-file-modified-sort="1781957779338" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="122">
+<div class="g-col-1" data-index="40" data-categories="d3NuJTJDbWVldGluZyUyQ3NlYXN0YXI=" data-listing-date-sort="1700640000000" data-listing-file-modified-sort="1781959433504" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="122">
 <a href="./posts/grace_L_WSN/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">
@@ -1805,7 +1805,7 @@ Nov 18, 2023
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="42" data-categories="d3NuJTJDbWVldGluZyUyQ3NlYXN0YXI=" data-listing-date-sort="1700035200000" data-listing-file-modified-sort="1781957779337" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="320">
+<div class="g-col-1" data-index="42" data-categories="d3NuJTJDbWVldGluZyUyQ3NlYXN0YXI=" data-listing-date-sort="1700035200000" data-listing-file-modified-sort="1781959433504" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="320">
 <a href="./posts/grace-ac-WSN/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">
@@ -1949,7 +1949,7 @@ Oct 9, 2023
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="46" data-categories="bXVzc2VsJTJDZ2Vub21lJTJDQ2hpbGU=" data-listing-date-sort="1696402800000" data-listing-file-modified-sort="1781957779338" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="539">
+<div class="g-col-1" data-index="46" data-categories="bXVzc2VsJTJDZ2Vub21lJTJDQ2hpbGU=" data-listing-date-sort="1696402800000" data-listing-file-modified-sort="1781959433506" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="539">
 <a href="./posts/mytilus-genome/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">
@@ -2021,7 +2021,7 @@ Sep 18, 2023
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="48" data-categories="cGFwZXIlMkNhY2lkaWNhdGlvbiUyQ295c3RlciUyQ29zdHJlYSUyQ3RhZy1zZXE=" data-listing-date-sort="1694761200000" data-listing-file-modified-sort="1781957779341" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="535">
+<div class="g-col-1" data-index="48" data-categories="cGFwZXIlMkNhY2lkaWNhdGlvbiUyQ295c3RlciUyQ29zdHJlYSUyQ3RhZy1zZXE=" data-listing-date-sort="1694761200000" data-listing-file-modified-sort="1781959433509" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="535">
 <a href="./posts/sr320-spencer-paper/index.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">

--- a/docs/posts/sr320-marineomics/index.html
+++ b/docs/posts/sr320-marineomics/index.html
@@ -121,8 +121,8 @@ gtag('config', 'G-CVEKGK5BS0', { 'anonymize_ip': true});
 <meta property="og:description" content="Steering the Future of Genomic Research in Aquatic Nonmodel Species">
 <meta property="og:image" content="https://faculty.washington.edu/sr320/img/marineomics.png">
 <meta property="og:site_name" content="robertslab.info">
-<meta property="og:image:height" content="930">
-<meta property="og:image:width" content="1694">
+<meta property="og:image:height" content="549">
+<meta property="og:image:width" content="1000">
 </head>
 
 <body class="nav-sidebar docked nav-fixed">

--- a/docs/projects.html
+++ b/docs/projects.html
@@ -387,7 +387,7 @@ Collaborative Research: URoL : Epigenetics 2: Predicting phenotypic and eco-evol
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-categories="Y29kJTJDQWxhc2thJTJDZXBpZ2VuZXRpY3MlMkMwMS1FRSUyQzAyLVJCRSUyQ29wZW4=" data-listing-file-modified-sort="1781958328949" data-listing-reading-time-sort="2" data-listing-word-count-sort="214">
+<div class="g-col-1" data-index="1" data-categories="Y29kJTJDQWxhc2thJTJDZXBpZ2VuZXRpY3MlMkMwMS1FRSUyQzAyLVJCRSUyQ29wZW4=" data-listing-file-modified-sort="1781959333338" data-listing-reading-time-sort="2" data-listing-word-count-sort="214">
 <a href="./research/cod.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <p class="card-img-top">

--- a/docs/research.html
+++ b/docs/research.html
@@ -404,7 +404,7 @@ window.Quarto = {
 
   </li>
 
-  <li data-index="2" data-categories="Y29kJTJDQWxhc2thJTJDZXBpZ2VuZXRpY3MlMkMwMS1FRSUyQzAyLVJCRSUyQ29wZW4=" data-listing-file-modified-sort="1781885092083" data-listing-reading-time-sort="2" data-listing-word-count-sort="214">
+  <li data-index="2" data-categories="Y29kJTJDQWxhc2thJTJDZXBpZ2VuZXRpY3MlMkMwMS1FRSUyQzAyLVJCRSUyQ29wZW4=" data-listing-file-modified-sort="1781959333338" data-listing-reading-time-sort="2" data-listing-word-count-sort="214">
     <span class="listing-title lead">Gene activity and genetic selection in Pacific cod reared under thermal stress</span><br>
 
     <a href="./research/cod.html" class="btn btn-primary">

--- a/docs/search.json
+++ b/docs/search.json
@@ -4462,6 +4462,20 @@
     "text": "Our lab investigates how marine organisms remember and respond to environmental change including how past and present conditions shape physiology, performance, and resilience across life stages and generations. We use integrative, mechanistic approaches that link molecular regulation to organismal outcomes, connecting genetics and epigenetics with physiology to reveal when responses are flexible, when they persist, and which signals best predict resilience in dynamic coastal systems.\nWe prioritize open, reproducible science. Our research products and workflows are shared broadly, including online lab notebooks, code, data, and presentations so results can be evaluated, reused, and extended. Below is a snapshot of current activity. Use the sidebar to explore our People, Projects, and Tools & Apps. For even more, visit our lab handbook.\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nFour Undergrads, Four Home Runs: A Spring Highlight Reel\n\n\nHighlighting Hannah Nowers, Noah Ozguner, Hazel Abrahamson-Amerine, and Christina Zhang’s undergraduate research\n\n\n\nSteven Roberts\n\n\nJun 11, 2026\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nUnlocking the Secrets of Tunicate Stress Responses\n\n\nHighlighting Celeste Valdivia’s Master’s Research\n\n\n\nSteven Roberts\n\n\nMar 19, 2026\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nDecoding Coral Gene Regulation: Tensor Decomposition and Elastic Nets Meet Marine Epigenetics\n\n\nA recap of Kathleen and Steven’s talk for the UW eScience Institute\n\n\n\nSteven Roberts\n\n\nMar 12, 2026\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nCan Oyster Parents Prepare Their Offspring for What’s Next?\n\n\nImmune Training at its Finest\n\n\n\nSteven Roberts\n\n\nJan 11, 2026\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nFrom Blue to Pink\n\n\nHow a Simple Dye is Revolutionizing Oyster Physiology Research\n\n\n\nSteven Roberts\n\n\nNov 11, 2025\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nBuilding Resilient Oysters: Launching the SORMI Project\n\n\n\n\n\n\nSteven Roberts\n\n\nSep 5, 2025\n\n\n\n\n\n\n\n\nNo matching items"
   },
   {
+    "objectID": "index.html#explore",
+    "href": "index.html#explore",
+    "title": "Roberts Lab",
+    "section": "Explore",
+    "text": "Explore\n\n\n  \n    \n    Projects\n    Active work across environmental epigenetics, reproduction, and aquaculture.\n  \n\n  \n    \n    Publications\n    Browse 100+ papers by organism and research theme.\n  \n\n  \n    \n    People\n    Meet the team, students, and lab alumni.\n  \n\n  \n    \n    Tools & Apps\n    Interactive apps and open, reusable resources."
+  },
+  {
+    "objectID": "index.html#recent-activity",
+    "href": "index.html#recent-activity",
+    "title": "Roberts Lab",
+    "section": "Recent activity",
+    "text": "Recent activity\n\n\n\n\n\n\n\n\n\n\nFour Undergrads, Four Home Runs: A Spring Highlight Reel\n\n\nHighlighting Hannah Nowers, Noah Ozguner, Hazel Abrahamson-Amerine, and Christina Zhang’s undergraduate research\n\n\n\nJun 11, 2026\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nUnlocking the Secrets of Tunicate Stress Responses\n\n\nHighlighting Celeste Valdivia’s Master’s Research\n\n\n\nMar 19, 2026\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nDecoding Coral Gene Regulation: Tensor Decomposition and Elastic Nets Meet Marine Epigenetics\n\n\nA recap of Kathleen and Steven’s talk for the UW eScience Institute\n\n\n\nMar 12, 2026\n\n\n\n\n\n\n\n\nNo matching items"
+  },
+  {
     "objectID": "people.html",
     "href": "people.html",
     "title": "Lab Members",

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -254,7 +254,7 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/notebooks.html</loc>
-    <lastmod>2026-06-20T03:24:26.383Z</lastmod>
+    <lastmod>2026-06-20T03:41:49.547Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-george-paper/index.html</loc>
@@ -262,15 +262,15 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-enrich/index.html</loc>
-    <lastmod>2026-06-20T12:27:35.140Z</lastmod>
+    <lastmod>2026-06-20T12:42:13.338Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-WSG/index.html</loc>
-    <lastmod>2026-06-19T16:04:52.043Z</lastmod>
+    <lastmod>2026-06-20T12:43:53.507Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-asi/index.html</loc>
-    <lastmod>2026-06-20T12:27:35.135Z</lastmod>
+    <lastmod>2026-06-20T12:42:13.337Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-prep/index.html</loc>
@@ -294,7 +294,7 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-altsplice/index.html</loc>
-    <lastmod>2026-06-20T12:27:35.138Z</lastmod>
+    <lastmod>2026-06-20T12:42:13.336Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/ariana-paper/index.html</loc>
@@ -310,7 +310,7 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/megan-rna/index.html</loc>
-    <lastmod>2026-06-19T16:04:52.041Z</lastmod>
+    <lastmod>2026-06-20T12:43:53.505Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-lsamp/index.html</loc>
@@ -326,7 +326,7 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-oyster_stage/index.html</loc>
-    <lastmod>2026-06-20T12:27:35.142Z</lastmod>
+    <lastmod>2026-06-20T12:42:13.338Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-boundless/index.html</loc>
@@ -338,7 +338,7 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-spencer-paper/index.html</loc>
-    <lastmod>2026-06-19T16:04:52.057Z</lastmod>
+    <lastmod>2026-06-20T12:43:53.509Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-ostras/index.html</loc>
@@ -362,7 +362,7 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/courses.html</loc>
-    <lastmod>2026-06-20T03:24:04.975Z</lastmod>
+    <lastmod>2026-06-20T03:41:49.474Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/research/e5.html</loc>
@@ -430,7 +430,7 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/research/cod.html</loc>
-    <lastmod>2026-06-19T16:04:52.083Z</lastmod>
+    <lastmod>2026-06-20T12:42:13.338Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/research/wsg-ec.html</loc>
@@ -474,7 +474,7 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-epiaqua/index.html</loc>
-    <lastmod>2026-06-19T16:04:52.054Z</lastmod>
+    <lastmod>2026-06-20T12:43:53.508Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-fhl/index.html</loc>
@@ -502,11 +502,11 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/grace-ac-WSN/index.html</loc>
-    <lastmod>2026-06-19T16:04:52.036Z</lastmod>
+    <lastmod>2026-06-20T12:43:53.504Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-cod/index.html</loc>
-    <lastmod>2026-06-20T12:25:40.549Z</lastmod>
+    <lastmod>2026-06-20T12:42:13.337Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-fellowships/index.html</loc>
@@ -514,7 +514,7 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/mytilus-genome/index.html</loc>
-    <lastmod>2026-06-19T16:04:52.042Z</lastmod>
+    <lastmod>2026-06-20T12:43:53.506Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/frontpage/sr320-polyic/index.html</loc>
@@ -542,7 +542,7 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/grace_L_WSN/index.html</loc>
-    <lastmod>2026-06-19T16:04:52.036Z</lastmod>
+    <lastmod>2026-06-20T12:43:53.504Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/sr320-mother/index.html</loc>
@@ -554,7 +554,7 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/posts/ariana-hatchery/index.html</loc>
-    <lastmod>2026-06-20T12:27:35.145Z</lastmod>
+    <lastmod>2026-06-20T12:42:13.336Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/publications/articles/the-caligus-rogercresseyi-mirnome-discovery-and-tr_2017.html</loc>
@@ -798,7 +798,7 @@
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/index.html</loc>
-    <lastmod>2026-06-20T12:25:47.013Z</lastmod>
+    <lastmod>2026-06-20T12:45:08.148Z</lastmod>
   </url>
   <url>
     <loc>https://faculty.washington.edu/sr320/people.html</loc>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -307,6 +307,64 @@
 }
 
 /* ------------------------------------------------------------------ */
+/* Home page — entry-point navigation cards                            */
+/* ------------------------------------------------------------------ */
+
+.lab-lead {
+  font-size: 1.2rem;
+  line-height: 1.5;
+  color: var(--lab-text);
+  margin: 1.25rem 0 0.5rem;
+}
+
+.nav-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem;
+  margin: 1.5rem 0 2.5rem;
+}
+
+.nav-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.5rem;
+  background: var(--lab-surface);
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  box-shadow: var(--lab-shadow);
+  text-decoration: none;
+  color: var(--lab-text);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.nav-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--lab-shadow-hover);
+  border-color: var(--lab-accent);
+  text-decoration: none;
+  color: var(--lab-text);
+}
+
+.nav-card .nav-card-icon {
+  font-size: 1.8rem;
+  color: var(--lab-accent);
+  line-height: 1;
+}
+
+.nav-card .nav-card-title {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--lab-primary);
+}
+
+.nav-card .nav-card-desc {
+  font-size: 0.88rem;
+  color: var(--lab-text-muted);
+  line-height: 1.45;
+}
+
+/* ------------------------------------------------------------------ */
 /* Notebooks page                                                      */
 /* ------------------------------------------------------------------ */
 
@@ -460,7 +518,8 @@
 
   .alumni-grid,
   .content-grid,
-  .web-projects-grid {
+  .web-projects-grid,
+  .nav-cards {
     grid-template-columns: 1fr;
   }
 }

--- a/index.qmd
+++ b/index.qmd
@@ -2,19 +2,57 @@
 title: "Roberts Lab"
 subtitle: "School of Aquatic and Fishery Sciences - University of Washington"
 title-block-banner: true
-toc: true
-
-listing: 
-  contents:
-    - "frontpage/*/*.qmd"
-  type: grid # or `default` or `table`; each type has its own set of yaml options to include
-  sort: "date desc" # can also sort on more than one field
-  categories: false # allows you to sort posts by assigned categories
+toc: false
+listing:
+  id: recent-activity
+  contents: posts
+  type: grid
+  sort: "date desc"
+  max-items: 3
+  categories: false
+  fields: [image, title, date, description]
   feed: true
 ---
 
 ![](img/lab-photo-02.jpg)
 
-Our lab investigates how marine organisms *remember* and respond to environmental change including how past and present conditions shape physiology, performance, and resilience across life stages and generations. We use integrative, mechanistic approaches that link molecular regulation to organismal outcomes, connecting genetics and epigenetics with physiology to reveal when responses are flexible, when they persist, and which signals best predict resilience in dynamic coastal systems.
+[How do marine organisms *remember* and respond to environmental change?]{.lab-lead}
 
-We prioritize open, reproducible science. Our research products and workflows are shared broadly, including online [lab notebooks](notebooks.qmd), [code, data](https://github.com/RobertsLab), and [presentations](https://faculty.washington.edu/sr320/publications.html#recent-presentations) so results can be evaluated, reused, and extended. Below is a snapshot of current activity. Use the sidebar to explore our People, Projects, and Tools & Apps. For even more, visit our [***lab handbook***](https://robertslab.github.io/resources/).
+We use integrative, mechanistic approaches that link molecular regulation to organismal outcomes — connecting genetics and epigenetics with physiology to reveal when responses are flexible, when they persist, and which signals best predict resilience in dynamic coastal systems. We prioritize open, reproducible science: our [code and data](https://github.com/RobertsLab), [lab notebooks](notebooks.qmd), and [presentations](publications.qmd) are shared broadly so results can be evaluated, reused, and extended. For even more, visit our [**lab handbook**](https://robertslab.github.io/resources/).
+
+## Explore
+
+```{=html}
+<div class="nav-cards">
+
+  <a class="nav-card" href="projects.html">
+    <span class="nav-card-icon"><i class="bi bi-diagram-3"></i></span>
+    <span class="nav-card-title">Projects</span>
+    <span class="nav-card-desc">Active work across environmental epigenetics, reproduction, and aquaculture.</span>
+  </a>
+
+  <a class="nav-card" href="publications.html">
+    <span class="nav-card-icon"><i class="bi bi-journal-text"></i></span>
+    <span class="nav-card-title">Publications</span>
+    <span class="nav-card-desc">Browse 100+ papers by organism and research theme.</span>
+  </a>
+
+  <a class="nav-card" href="people.html">
+    <span class="nav-card-icon"><i class="bi bi-people"></i></span>
+    <span class="nav-card-title">People</span>
+    <span class="nav-card-desc">Meet the team, students, and lab alumni.</span>
+  </a>
+
+  <a class="nav-card" href="tools-and-apps.html">
+    <span class="nav-card-icon"><i class="bi bi-grid-3x3-gap"></i></span>
+    <span class="nav-card-title">Tools &amp; Apps</span>
+    <span class="nav-card-desc">Interactive apps and open, reusable resources.</span>
+  </a>
+
+</div>
+```
+
+## Recent activity
+
+::: {#recent-activity}
+:::

--- a/styles.css
+++ b/styles.css
@@ -307,6 +307,64 @@
 }
 
 /* ------------------------------------------------------------------ */
+/* Home page — entry-point navigation cards                            */
+/* ------------------------------------------------------------------ */
+
+.lab-lead {
+  font-size: 1.2rem;
+  line-height: 1.5;
+  color: var(--lab-text);
+  margin: 1.25rem 0 0.5rem;
+}
+
+.nav-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem;
+  margin: 1.5rem 0 2.5rem;
+}
+
+.nav-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.5rem;
+  background: var(--lab-surface);
+  border: 1px solid var(--lab-border);
+  border-radius: var(--lab-radius);
+  box-shadow: var(--lab-shadow);
+  text-decoration: none;
+  color: var(--lab-text);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.nav-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--lab-shadow-hover);
+  border-color: var(--lab-accent);
+  text-decoration: none;
+  color: var(--lab-text);
+}
+
+.nav-card .nav-card-icon {
+  font-size: 1.8rem;
+  color: var(--lab-accent);
+  line-height: 1;
+}
+
+.nav-card .nav-card-title {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--lab-primary);
+}
+
+.nav-card .nav-card-desc {
+  font-size: 0.88rem;
+  color: var(--lab-text-muted);
+  line-height: 1.45;
+}
+
+/* ------------------------------------------------------------------ */
 /* Notebooks page                                                      */
 /* ------------------------------------------------------------------ */
 
@@ -460,7 +518,8 @@
 
   .alumni-grid,
   .content-grid,
-  .web-projects-grid {
+  .web-projects-grid,
+  .nav-cards {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
Replace the thin homepage (hero + two paragraphs + an empty listing that pointed at a non-existent frontpage/ directory) with a focused landing:

- Tighter hero: a one-line value statement ("How do marine organisms remember and respond to environmental change?") styled via a new .lab-lead class, plus a condensed intro paragraph.
- An "Explore" section with four entry-point cards (Projects, Publications, People, Tools & Apps) using a new centralized .nav-card component built on the existing design tokens (teal icons, navy titles, hover lift). Bootstrap Icons for the glyphs.
- A real "Recent activity" listing that pulls the 3 most recent posts (replacing the broken empty frontpage listing), so the homepage now actually shows current lab activity with images.

The .nav-card / .lab-lead styles live in styles.css with the rest of the component CSS and inherit the .quarto-dark token overrides, so they work in both light and dark mode and collapse to a single column on mobile.

Verified in preview: cards render correctly in light and dark mode, lead is visually distinct, and the recent-activity listing shows three real posts.